### PR TITLE
fix dir does not exist on initialize_new_project

### DIFF
--- a/ingenious/cli.py
+++ b/ingenious/cli.py
@@ -281,7 +281,9 @@ def initialize_new_project():
     if template_profile_path.exists():
         # Get user home directory
         home_dir = os.path.expanduser("~")
-        profile_path = Path(home_dir) / Path(".ingenious") / Path("profiles.yml")
+        profile_dir_path = Path(home_dir) / Path(".ingenious")
+        os.makedirs(profile_dir_path, exist_ok=True)
+        profile_path = profile_dir_path / Path("profiles.yml")
         shutil.copy2(template_profile_path, profile_path)
         console.print(
             f"[info]Profile file created successfully created at {profile_path}[/info]"


### PR DESCRIPTION
On inisitialising project, if the ".ingenious" file does not exist then it will through an error stating the path cannot be found. 

I have added in a create directory function to ensure this file exists before proceeding. 